### PR TITLE
Finish reusable mat confirm dialog

### DIFF
--- a/src/app/pages/auth/login/login.component.ts
+++ b/src/app/pages/auth/login/login.component.ts
@@ -33,7 +33,7 @@ export class LoginComponent implements OnInit {
         if (password === user.password) {
           this.snackMessageService.openSnackBar('Login!');
         } else {
-          this.snackMessageService.openSnackBar(`Password doesn't match the email!`, 'error');
+          this.snackMessageService.openSnackBar(`Password doesn't correct for the email!`, 'error');
         }
       } else {
         this.snackMessageService.openSnackBar('No user with such an email!', 'error');

--- a/src/app/pages/system/interview/presentationals/interview-card/interview-card.component.html
+++ b/src/app/pages/system/interview/presentationals/interview-card/interview-card.component.html
@@ -1,17 +1,21 @@
 <div class="card">
   <figure class="card__figure">
-    <a href="https://www.tut.by/" [target]="interview.id" [title]="'Go to ' + interview.candidate['name'] + '\'s page'">
+    <a
+      href="https://www.tut.by/"
+      [target]="interview.id"
+      [title]="'Go to ' + interview.candidate['name'] + '\'s page'"
+    >
       <img [src]="interview.candidate['photo']" class="card__img" />
     </a>
   </figure>
   <section class="cart__content">
-    <span
-      ><i
-        >{{ interview.candidate['name'] }}
-        {{ interview.candidate['surname'] }}</i
-      >
-      on <i>{{ interview.vacancy['title'] }}</i></span
-    >
+    <span>
+      <i>
+        {{ interview.candidate['name'] }}
+        {{ interview.candidate['surname'] }}
+      </i>
+      on <i>{{ interview.vacancy['title'] }}</i>
+    </span>
 
     <span
       >at <span class="cart__time"> {{ interview.time }}</span></span
@@ -24,7 +28,12 @@
     <mat-menu #menu="matMenu" xPosition="after">
       <a mat-menu-item title="Go to the interview page"> <span>Go</span> </a>
       <a mat-menu-item> <span>Edit</span> </a>
-      <a mat-menu-item> <span style="color: var(--color-warn);">Delete</span> </a>
+      <a
+        mat-menu-item
+        (click)="onDeleteInterview()"
+      >
+        <span style="color: var(--color-warn);">Delete</span>
+      </a>
     </mat-menu>
   </div>
 </div>

--- a/src/app/pages/system/interview/presentationals/interview-card/interview-card.component.ts
+++ b/src/app/pages/system/interview/presentationals/interview-card/interview-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { InterviewClient } from 'src/app/core/models/interview.model';
+import { MatConfirmService } from 'src/app/ui/modules/reusable-mat-confirm/mat-confirm-service';
 
 @Component({
   selector: 'hr-interview-card',
@@ -9,9 +10,14 @@ import { InterviewClient } from 'src/app/core/models/interview.model';
 export class InterviewCardComponent implements OnInit {
   @Input() interview: InterviewClient;
 
-  constructor() { }
+  constructor(private matConfirm: MatConfirmService) { }
 
   ngOnInit() {
+  }
+
+  onDeleteInterview() {
+    const dialogRef = this.matConfirm.open('Are you sure you wanna delete an interview?');
+    dialogRef.afterClosed().subscribe(console.log);
   }
 
 }

--- a/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.html
+++ b/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.html
@@ -1,0 +1,34 @@
+<div class="dialog">
+  <h2 mat-dialog-title class="dialog__title">Confirm</h2>
+
+  <p class="dialog__content">
+    {{data}}
+  </p>
+
+  <div
+    mat-dialog-actions
+    fxLayout="row nowrap"
+    fxLayoutGap="1rem"
+    class="dialog__actions"
+  >
+    <button
+      type="button"
+      mat-raised-button
+      color="primary"
+      [mat-dialog-close]="false"
+      fxFlex="50"
+      cdkFocusInitial
+    >
+      NO
+    </button>
+    <button
+      type="button"
+      mat-raised-button
+      color="warn"
+      [mat-dialog-close]="true"
+      fxFlex="50"
+    >
+      YES
+    </button>
+  </div>
+</div>

--- a/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.scss
+++ b/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.scss
@@ -1,0 +1,16 @@
+.dialog {
+  padding: .7rem 1rem 2rem;
+}
+
+.dialog__title {
+  font-size: 2.5rem;
+  text-align: center;
+}
+
+.dialog__content {
+  font-style: italic;
+}
+
+.dialog__actions {
+  margin-top: 1.5rem;;
+}

--- a/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.spec.ts
+++ b/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DialogComponent } from './dialog.component';
+
+describe('DialogComponent', () => {
+  let component: DialogComponent;
+  let fixture: ComponentFixture<DialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.ts
+++ b/src/app/ui/modules/reusable-mat-confirm/dialog/dialog.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+  selector: 'hr-dialog',
+  templateUrl: './dialog.component.html',
+  styleUrls: ['./dialog.component.scss']
+})
+export class DialogComponent implements OnInit {
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data) { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/ui/modules/reusable-mat-confirm/mat-confirm-service.ts
+++ b/src/app/ui/modules/reusable-mat-confirm/mat-confirm-service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material';
+import { DialogComponent } from './dialog/dialog.component';
+
+@Injectable()
+export class MatConfirmService {
+  constructor(private matDialog: MatDialog) {}
+
+  open(message: string): MatDialogRef<DialogComponent, any> {
+    return this.matDialog.open(DialogComponent, {
+      data: message
+    });
+  }
+}

--- a/src/app/ui/modules/reusable-mat-confirm/reusable-mat-confirm.module.spec.ts
+++ b/src/app/ui/modules/reusable-mat-confirm/reusable-mat-confirm.module.spec.ts
@@ -1,0 +1,13 @@
+import { ReusableMatConfirmModule } from './reusable-mat-confirm.module';
+
+describe('ReusableMatConfirmModule', () => {
+  let reusableMatConfirmModule: ReusableMatConfirmModule;
+
+  beforeEach(() => {
+    reusableMatConfirmModule = new ReusableMatConfirmModule();
+  });
+
+  it('should create an instance', () => {
+    expect(reusableMatConfirmModule).toBeTruthy();
+  });
+});

--- a/src/app/ui/modules/reusable-mat-confirm/reusable-mat-confirm.module.ts
+++ b/src/app/ui/modules/reusable-mat-confirm/reusable-mat-confirm.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '../../material/material.module';
+import { DialogComponent } from './dialog/dialog.component';
+import { MatConfirmService } from './mat-confirm-service';
+import { FlexLayoutModule } from '@angular/flex-layout';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MaterialModule,
+    FlexLayoutModule
+  ],
+  declarations: [DialogComponent],
+  providers: [MatConfirmService],
+  entryComponents: [DialogComponent]
+})
+export class ReusableMatConfirmModule {
+
+}

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -9,6 +9,7 @@ import { HrCalendarComponent } from './components/calendar/hr-calendar.component
 
 import { SnackMessagePbService } from './services/snack-message-pb.service';
 import { SnackMessageService } from './services/snack-messgae.service';
+import { ReusableMatConfirmModule } from './modules/reusable-mat-confirm/reusable-mat-confirm.module';
 
 @NgModule({
   declarations: [SnackMessageComponent, HrCalendarComponent],
@@ -16,12 +17,14 @@ import { SnackMessageService } from './services/snack-messgae.service';
     CommonModule,
     FlexLayoutModule,
     MaterialModule,
+    ReusableMatConfirmModule,
     NgxMaterialTimepickerModule.forRoot()
   ],
   providers: [SnackMessagePbService, SnackMessageService],
   entryComponents: [SnackMessageComponent],
   exports: [
     MaterialModule,
+    ReusableMatConfirmModule,
     FlexLayoutModule,
     NgxMaterialTimepickerModule,
     HrCalendarComponent


### PR DESCRIPTION
How to use?
If you need a confirm action from user before doing something - just inject MatConfirmService into your component and call .open(message) method. This method will return MatDialogRef - so after closing a confirm dialog you can listen for closing event with .afterClosed() method which return an Observable with result (true or false in our case).